### PR TITLE
Initial work to support the Bandwidth v2 Numbers API.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Bandwidth/go-bandwidth
+
+go 1.12
+
+require github.com/google/go-querystring v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/v2/numbers/account.go
+++ b/v2/numbers/account.go
@@ -1,0 +1,40 @@
+package numbers
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+// Account information
+type Account struct {
+	XMLName                   xml.Name `xml:"Account"`
+	AccountID                 string   `xml:"AccountId"`
+	AssociatedCatapultAccount string   `xml:"AssociatedCatapultAccount"`
+	GlobalAccountNumber       string   `xml:"GlobalAccountNumber"`
+	CompanyName               string   `xml:"CompanyName"`
+	AccountType               string   `xml:"AccountType"`
+	NenaID                    string   `xml:"NenaId"`
+	CustomerSegment           string   `xml:"CustomerSegment"`
+	Tiers                     []int    `xml:"Tiers>Tier"`
+	Address                   Address  `xml:"Address"`
+	Contact                   Contact  `xml:"Contact"`
+	AltSpid                   string   `xml:"AltSpid"`
+	SPID                      string   `xml:"SPID"`
+	PortCarrierType           string   `xml:"PortCarrierType"`
+}
+
+// AccountResponse is the response for GetAccount.
+type AccountResponse struct {
+	XMLName xml.Name `xml:"AccountResponse"`
+	Account Account  `xml:"Account"`
+}
+
+// GetAccount returns account information.
+func (c *Client) GetAccount() (*AccountResponse, error) {
+	respBody := &AccountResponse{}
+	err := c.makeRequest(http.MethodGet, "", nil, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}

--- a/v2/numbers/addresses.go
+++ b/v2/numbers/addresses.go
@@ -1,0 +1,53 @@
+package numbers
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+// Address for an Account.
+type Address struct {
+	XMLName          xml.Name `xml:"Address"`
+	HouseNumber      int      `xml:"HouseNumber"`
+	HouseSuffix      string   `xml:"HouseSuffix"`
+	PreDirectional   string   `xml:"PreDirectional"`
+	StreetName       string   `xml:"StreetName"`
+	StreetSuffix     string   `xml:"StreetSuffix"`
+	PostDirectional  string   `xml:"PostDirectional"`
+	AddressLine2     string   `xml:"AddressLine2"`
+	City             string   `xml:"City"`
+	StateCode        string   `xml:"StateCode"`
+	Zip              int      `xml:"Zip"`
+	PlusFour         int      `xml:"PlusFour"`
+	County           string   `xml:"County"`
+	Country          string   `xml:"Country"`
+	AddressType      string   `xml:"AddressType"`
+	EndpointCount    int      `xml:"EndpointCount"`
+	ValidationStatus string   `xml:"ValidationStatus"`
+}
+
+// AddressesResponse is the response for GetAddresses.
+type AddressesResponse struct {
+	XMLName    xml.Name   `xml:"AddressesResponse"`
+	TotalCount int        `xml:"TotalCount"`
+	Addresses  []*Address `xml:"Addresses"`
+}
+
+// GetAddressesQuery is query parameters of GetAddresses.
+type GetAddressesQuery struct {
+	E911LocationID string `url:"e911locationid,omitempty"`
+	Page           int    `url:"page,omitempty"`
+	Size           int    `url:"size,omitempty"`
+	Suggestions    string `url:"suggestions,omitempty"`
+	Type           string `url:"type,omitempty"`
+}
+
+// GetAddresses returns addresses for the account.
+func (c *Client) GetAddresses(query *GetAddressesQuery) (*AddressesResponse, error) {
+	respBody := &AddressesResponse{}
+	err := c.makeRequest(http.MethodGet, "addresses", query, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}

--- a/v2/numbers/applications.go
+++ b/v2/numbers/applications.go
@@ -1,0 +1,117 @@
+package numbers
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+)
+
+const (
+	// ApplicationServiceTypeMessagingV2 is the messaging V2 service type.
+	ApplicationServiceTypeMessagingV2 = "Messaging-V2"
+	// ApplicationServiceTypeVoiceV2 is the voice V2 service type.
+	ApplicationServiceTypeVoiceV2 = "Voice-V2"
+)
+
+// ApplicationCallbackCreds is callback credentials for an application.
+type ApplicationCallbackCreds struct {
+	XMLName  xml.Name `xml:"CallbackCreds"`
+	UserID   string   `xml:"UserId"`
+	Password string   `xml:"Password"`
+}
+
+// Application is an application in an Account.
+type Application struct {
+	XMLName                  xml.Name                  `xml:"Application"`
+	ApplicationID            string                    `xml:"ApplicationId"`
+	ServiceType              string                    `xml:"ServiceType"`
+	AppName                  string                    `xml:"AppName"`
+	MsgCallbackURL           string                    `xml:"MsgCallbackUrl"`
+	CallInitiatedCallbackURL string                    `xml:"CallInitiatedCallbackUrl"`
+	CallInitiatedMethod      string                    `xml:"CallInitiatedMethod"`
+	CallStatusCallbackURL    string                    `xml:"CallStatusCallbackUrl"`
+	CallStatusMethod         string                    `xml:"CallStatusMethod"`
+	ApplicationCallbackCreds *ApplicationCallbackCreds `xml:"CallbackCreds"`
+}
+
+// ApplicationsResponse is the response to GetApplications.
+type ApplicationsResponse struct {
+	XMLName      xml.Name      `xml:"ApplicationProvisioningResponse"`
+	Applications []Application `xml:"ApplicationList>Application"`
+}
+
+// GetApplications returns applications for the account.
+func (c *Client) GetApplications() (*ApplicationsResponse, error) {
+	respBody := &ApplicationsResponse{}
+	err := c.makeRequest(http.MethodGet, "applications", nil, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
+// ApplicationResponse is the response to GetApplication, CreateApplication, and UpdateApplication.
+type ApplicationResponse struct {
+	XMLName     xml.Name    `xml:"ApplicationProvisioningResponse"`
+	Application Application `xml:"Application"`
+}
+
+// GetApplication gets an application.
+func (c *Client) GetApplication(appID string) (*ApplicationResponse, error) {
+	respBody := &ApplicationResponse{}
+	err := c.makeRequest(http.MethodGet, fmt.Sprintf("applications/%s", appID), nil, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
+// CreateApplication creates a new application.
+func (c *Client) CreateApplication(data *Application) (*ApplicationResponse, error) {
+	respBody := &ApplicationResponse{}
+	err := c.makeRequest(http.MethodPost, "applications", data, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
+// UpdateApplication updates an application.
+func (c *Client) UpdateApplication(data *Application) (*ApplicationResponse, error) {
+	respBody := &ApplicationResponse{}
+	err := c.makeRequest(http.MethodPut, fmt.Sprintf("applications/%s", data.ApplicationID), data, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
+// DeleteApplication deletes an application.
+func (c *Client) DeleteApplication(appID string) error {
+	return c.makeRequest(http.MethodDelete, fmt.Sprintf("applications/%s", appID), nil, nil)
+}
+
+// AssociatedSipPeer is a SIP peer associated to an application.
+type AssociatedSipPeer struct {
+	XMLName  xml.Name `xml:"AssociatedSipPeer"`
+	SiteID   string   `xml:"SiteId"`
+	SiteName string   `xml:"SiteName"`
+	PeerID   string   `xml:"PeerId"`
+	PeerName string   `xml:"PeerName"`
+}
+
+// AssociatedSipPeersResponse is the response to GetApplicationAssociatedSipPeers.
+type AssociatedSipPeersResponse struct {
+	XMLName            xml.Name             `xml:"AssociatedSipPeersResponse"`
+	AssociatedSipPeers []*AssociatedSipPeer `xml:"AssociatedSipPeers"`
+}
+
+// GetApplicationAssociatedSipPeers gets the associated SIP peers for an application.
+func (c *Client) GetApplicationAssociatedSipPeers(appID string) (*AssociatedSipPeersResponse, error) {
+	respBody := &AssociatedSipPeersResponse{}
+	err := c.makeRequest(http.MethodPut, fmt.Sprintf("applications/%s/associatedsippeers", appID), nil, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}

--- a/v2/numbers/availableNumbers.go
+++ b/v2/numbers/availableNumbers.go
@@ -1,0 +1,40 @@
+package numbers
+
+import (
+	"encoding/xml"
+	"net/http"
+)
+
+// AvailableNumbersResponse is the response for GetAvailableNumbers.
+type AvailableNumbersResponse struct {
+	XMLName          xml.Name `xml:"SearchResult"`
+	ResultCount      int      `xml:"ResultCount"`
+	TelephoneNumbers []string `xml:"TelephoneNumberList>TelephoneNumber"`
+}
+
+// GetAvailableNumbersQuery is the query parameters for GetAvailableNumbers.
+type GetAvailableNumbersQuery struct {
+	LCA                     bool   `url:"LCA,omitempty"`
+	AreaCode                int    `url:"areaCode,omitempty"`
+	City                    string `url:"city,omitempty"`
+	EndsIn                  bool   `url:"endsIn,omitempty"`
+	Lata                    int    `url:"lata,omitempty"`
+	LocalVanity             string `url:"localVanity,omitempty"`
+	OrderBy                 string `url:"orderBy,omitempty"`
+	Quantity                int    `url:"quantity"`
+	RateCenter              string `url:"rateCenter,omitempty"`
+	State                   string `url:"state,omitempty"`
+	TollFreeVanity          string `url:"tollFreeVanity,omitempty"`
+	TollFreeWildCardPattern string `url:"tollFreeWildCardPattern,omitempty"`
+	Zip                     int    `url:"zip,omitempty"`
+}
+
+// GetAvailableNumbers returns a list of available numbers based on the provided query.
+func (c *Client) GetAvailableNumbers(query *GetAvailableNumbersQuery) (*AvailableNumbersResponse, error) {
+	respBody := &AvailableNumbersResponse{}
+	err := c.makeRequest(http.MethodGet, "availableNumbers", query, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}

--- a/v2/numbers/client.go
+++ b/v2/numbers/client.go
@@ -1,0 +1,154 @@
+package numbers
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-querystring/query"
+)
+
+const (
+	// DefaultEndpoint is the default endpoint to communicate with Bandwidth Numbers V2 API.
+	DefaultEndpoint = "https://dashboard.bandwidth.com"
+)
+
+// Client provides a client to communicate with the Bandwidth Numbers V2 API.
+type Client struct {
+	accountID string
+	username  string
+	password  string
+
+	endpoint string
+	client   *http.Client
+}
+
+// NewClient makes a new client to communicate with the Bandwidth Numbers V2 API.
+func NewClient(accountID string, username string, password string, endpoint string, client *http.Client) (*Client, error) {
+	if accountID == "" || username == "" || password == "" || endpoint == "" || client == nil {
+		return nil, errors.New(`Missing auth data. Please use api := numbers.NewClient("accountId", "username", "password", "endpoint", http.DefaultClient)`)
+	}
+	return &Client{
+		accountID: accountID,
+		username:  username,
+		password:  password,
+		endpoint:  strings.TrimRight(endpoint, "/"),
+		client:    client,
+	}, nil
+}
+
+// NewDefaultClient makes a new client communicating with the Bandwidth Numbers V2 API at the
+// DefaultEndpoint and with the http.DefaultClient.
+func NewDefaultClient(accountID string, username string, password string) (*Client, error) {
+	if accountID == "" || username == "" || password == "" {
+		return nil, errors.New(`Missing auth data. Please use api := numbers.NewDefaultClient("accountId", "username", "password")`)
+	}
+	return NewClient(accountID, username, password, DefaultEndpoint, http.DefaultClient)
+}
+
+// ClientError is an error returned when performing a client operation and the
+// API responded with an error.
+type ClientError struct {
+	XMLName     xml.Name `xml:"Error"`
+	StatusCode  int      `xml:"-"`
+	Code        string   `xml:"Code"`
+	Description string   `xml:"Description"`
+}
+
+func (e *ClientError) Error() string {
+	if e.Code != "" && e.Description != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Description)
+	} else if e.Code != "" {
+		return fmt.Sprintf("%s", e.Code)
+	}
+	return fmt.Sprintf("HTTP error %d", e.StatusCode)
+}
+
+// prepareURL constructs the request URL.
+func (c *Client) prepareURL(path string) string {
+	return strings.TrimRight(fmt.Sprintf("%s/api/accounts/%s/%s", c.endpoint, c.accountID, strings.TrimLeft(path, "/")), "/")
+}
+
+// createRequest creates the HTTP request.
+func (c *Client) createRequest(method string, path string, data interface{}) (*http.Request, error) {
+	request, err := http.NewRequest(method, c.prepareURL(path), nil)
+	if err != nil {
+		return nil, err
+	}
+	request.SetBasicAuth(c.username, c.password)
+	request.Header.Set("Accept", "application/xml")
+	request.Header.Set("User-Agent", "go-bandwidth/v2/numbers")
+	if method == http.MethodGet && data != nil {
+		urlValues, err := query.Values(data)
+		if err != nil {
+			return nil, err
+		}
+		request.URL.RawQuery = urlValues.Encode()
+	} else if (method == http.MethodPost || method == http.MethodPut) && data != nil {
+		body, err := xml.Marshal(&data)
+		if err != nil {
+			return nil, err
+		}
+		request.Body = nopCloser{bytes.NewReader(body)}
+		request.Header.Set("Content-Type", "application/xml")
+	}
+	return request, nil
+}
+
+type errorResponse struct {
+	Error ClientError `xml:"Error"`
+}
+
+// parseResponse parsed the HTTP response into the responseBody
+func (c *Client) parseResponse(response *http.Response, responseBody interface{}) error {
+	defer response.Body.Close()
+	rawXML, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode >= 200 && response.StatusCode < 400 {
+		if len(rawXML) > 0 {
+			return xml.Unmarshal(rawXML, &responseBody)
+		}
+		return nil
+	}
+	var errorResp errorResponse
+	if len(rawXML) > 0 {
+		err = xml.Unmarshal(rawXML, &errorResp)
+		if err != nil {
+			return err
+		}
+		errorResp.Error.StatusCode = response.StatusCode
+		return &errorResp.Error
+	}
+	errorResp.Error.StatusCode = response.StatusCode
+	return &errorResp.Error
+}
+
+// makeRequest is a shortcut to createRequest, http client.Do, and parseResponse.
+func (c *Client) makeRequest(method string, path string, data interface{}, responseBody interface{}) error {
+	request, err := c.createRequest(method, path, data)
+	if err != nil {
+		return err
+	}
+	response, err := c.client.Do(request)
+	if err != nil {
+		return err
+	}
+	return c.parseResponse(response, responseBody)
+}
+
+// nopCloser is an io.ReaderCloser that does nothing for the close.
+type nopCloser struct {
+	io.Reader
+}
+
+// Close does nothing.
+func (nopCloser) Close() error {
+	return nil
+}

--- a/v2/numbers/contacts.go
+++ b/v2/numbers/contacts.go
@@ -1,0 +1,12 @@
+package numbers
+
+import "encoding/xml"
+
+// Contact for an Account.
+type Contact struct {
+	XMLName   xml.Name `xml:"Contact"`
+	FirstName string   `xml:"FirstName"`
+	LastName  string   `xml:"LastName"`
+	Phone     string   `xml:"Phone"`
+	Email     string   `xml:"Email"`
+}

--- a/v2/numbers/disconnects.go
+++ b/v2/numbers/disconnects.go
@@ -1,0 +1,52 @@
+package numbers
+
+import (
+	"encoding/xml"
+	"net/http"
+	"time"
+)
+
+const (
+	// DisconnectModeNormal used on disconnect to set priority of disconnect.
+	DisconnectModeNormal = "normal"
+	// ProtectedTrue used on disconnected to mark the telephone numbers protected.
+	ProtectedTrue = "TRUE"
+	// ProtectedFalse used on disconnected to mark the telephone numbers as not protected.
+	ProtectedFalse = "FALSE"
+	// ProtectedUnchanged used on disconnect to to leave telephone numbers protected status unchanged.
+	ProtectedUnchanged = "UNCHANGED"
+)
+
+// DisconnectTelephoneNumberOrderType is an order type to disconnect a list of telephone numbers.
+type DisconnectTelephoneNumberOrderType struct {
+	XMLName          xml.Name `xml:"DisconnectTelephoneNumberOrderType"`
+	TelephoneNumbers []string `xml:"TelephoneNumberList>TelephoneNumber"`
+	DisconnectMode   string   `xml:"DisconnectMode,omitempty"`
+	Protected        string   `xml:"UNCHANGED,omitempty"`
+}
+
+// DisconnectTelephoneNumberOrder is an order to disconnect a list of telephone numbers.
+type DisconnectTelephoneNumberOrder struct {
+	XMLName                        xml.Name                            `xml:"DisconnectTelephoneNumberOrder"`
+	ID                             string                              `xml:"id,omitempty"`
+	Name                           string                              `xml:"name,omitempty"`
+	CustomerOrderID                string                              `xml:"CustomerOrderID,omitempty"`
+	OrderCreateDate                *time.Time                          `xml:"OrderCreateDate,omitempty"`
+	DisconnectTelephoneNumberOrder *DisconnectTelephoneNumberOrderType `xml:"DisconnectTelephoneNumberOrderType"`
+}
+
+// DisconnectTelephoneNumberOrderResponse is the response for CreateDisconnectOrder.
+type DisconnectTelephoneNumberOrderResponse struct {
+	XMLName      xml.Name                       `xml:"DisconnectTelephoneNumberOrderResponse"`
+	OrderRequest DisconnectTelephoneNumberOrder `xml:"orderRequest"`
+}
+
+// CreateDisconnectOrder creates a new disconnect order.
+func (c *Client) CreateDisconnectOrder(data *DisconnectTelephoneNumberOrder) (*DisconnectTelephoneNumberOrderResponse, error) {
+	respBody := &DisconnectTelephoneNumberOrderResponse{}
+	err := c.makeRequest(http.MethodPost, "disconnects", data, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}

--- a/v2/numbers/disconnects.go
+++ b/v2/numbers/disconnects.go
@@ -22,12 +22,20 @@ type DisconnectTelephoneNumberOrderType struct {
 	XMLName          xml.Name `xml:"DisconnectTelephoneNumberOrderType"`
 	TelephoneNumbers []string `xml:"TelephoneNumberList>TelephoneNumber"`
 	DisconnectMode   string   `xml:"DisconnectMode,omitempty"`
-	Protected        string   `xml:"UNCHANGED,omitempty"`
+	Protected        string   `xml:"Protected,omitempty"`
 }
 
 // DisconnectTelephoneNumberOrder is an order to disconnect a list of telephone numbers.
 type DisconnectTelephoneNumberOrder struct {
 	XMLName                        xml.Name                            `xml:"DisconnectTelephoneNumberOrder"`
+	Name                           string                              `xml:"name,omitempty"`
+	CustomerOrderID                string                              `xml:"CustomerOrderID,omitempty"`
+	DisconnectTelephoneNumberOrder *DisconnectTelephoneNumberOrderType `xml:"DisconnectTelephoneNumberOrderType"`
+}
+
+// DisconnectTelephoneNumberOrderRequest is the order request inside a disconnect order response.
+type DisconnectTelephoneNumberOrderRequest struct {
+	XMLName                        xml.Name                            `xml:"orderRequest"`
 	ID                             string                              `xml:"id,omitempty"`
 	Name                           string                              `xml:"name,omitempty"`
 	CustomerOrderID                string                              `xml:"CustomerOrderID,omitempty"`
@@ -37,8 +45,9 @@ type DisconnectTelephoneNumberOrder struct {
 
 // DisconnectTelephoneNumberOrderResponse is the response for CreateDisconnectOrder.
 type DisconnectTelephoneNumberOrderResponse struct {
-	XMLName      xml.Name                       `xml:"DisconnectTelephoneNumberOrderResponse"`
-	OrderRequest DisconnectTelephoneNumberOrder `xml:"orderRequest"`
+	XMLName      xml.Name                              `xml:"DisconnectTelephoneNumberOrderResponse"`
+	OrderRequest DisconnectTelephoneNumberOrderRequest `xml:"orderRequest"`
+	OrderStatus  string                                `xml:"OrderStatus"`
 }
 
 // CreateDisconnectOrder creates a new disconnect order.

--- a/v2/numbers/orders.go
+++ b/v2/numbers/orders.go
@@ -1,0 +1,161 @@
+package numbers
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	// OrderStatusComplete is a completed order.
+	OrderStatusComplete = "COMPLETE"
+	// OrderStatusFailed is a failed order.
+	OrderStatusFailed = "FAILED"
+	// OrderStatusReceived is a received order.
+	OrderStatusReceived = "RECEIVED"
+)
+
+// ExistingTelephoneNumberOrderType is an order type defining existing phone numbers normally found
+// using the GetAvailableNumbers.
+type ExistingTelephoneNumberOrderType struct {
+	XMLName          xml.Name `xml:"ExistingTelephoneNumberOrderType"`
+	TelephoneNumbers []string `xml:"TelephoneNumberList>TelephoneNumber"`
+	ReservationIDs   []string `xml:"ReservationIdList>ReservationId"`
+}
+
+// AreaCodeSearchAndOrderType is an order type defining an order based on an area code.
+type AreaCodeSearchAndOrderType struct {
+	XMLName  xml.Name `xml:"AreaCodeSearchAndOrderType"`
+	AreaCode int      `xml:"AreaCode"`
+	Quantity int      `xml:"Quantity"`
+}
+
+// RateCenterSearchAndOrderType is an order type defining an order based on rate center.
+type RateCenterSearchAndOrderType struct {
+	XMLName    xml.Name `xml:"RateCenterSearchAndOrderType"`
+	RateCenter string   `xml:"RateCenter"`
+	State      string   `xml:"State"`
+	Quantity   int      `xml:"Quantity"`
+}
+
+// TollFreeVanitySearchAndOrderType is an order type defining an order based on toll-free vanity search.
+type TollFreeVanitySearchAndOrderType struct {
+	XMLName        xml.Name `xml:"TollFreeVanitySearchAndOrderType"`
+	TollFreeVanity string   `xml:"TollFreeVanity"`
+	Quantity       int      `xml:"Quantity"`
+}
+
+// TollFreeWildCharSearchAndOrderType is an order type defining an order based on toll-free wildcard search.
+type TollFreeWildCharSearchAndOrderType struct {
+	XMLName                 xml.Name `xml:"TollFreeWildCharSearchAndOrderType"`
+	TollFreeWildCardPattern string   `xml:"TollFreeWildCardPattern"`
+	Quantity                int      `xml:"Quantity"`
+}
+
+// StateSearchAndOrderType is an order type defining an order based on state.
+type StateSearchAndOrderType struct {
+	XMLName  xml.Name `xml:"StateSearchAndOrderType"`
+	State    string   `xml:"State"`
+	Quantity int      `xml:"Quantity"`
+}
+
+// CitySearchAndOrderType is an order type defining an order based on city.
+type CitySearchAndOrderType struct {
+	XMLName  xml.Name `xml:"CitySearchAndOrderType"`
+	City     string   `xml:"City"`
+	State    string   `xml:"State"`
+	Quantity int      `xml:"Quantity"`
+}
+
+// ZIPSearchAndOrderType is an order type defining an order based on zip code.
+type ZIPSearchAndOrderType struct {
+	XMLName  xml.Name `xml:"ZIPSearchAndOrderType"`
+	Zip      string   `xml:"Zip"`
+	Quantity int      `xml:"Quantity"`
+}
+
+// LATASearchAndOrderType is an order type defining an order based on lata.
+type LATASearchAndOrderType struct {
+	XMLName  xml.Name `xml:"LATASearchAndOrderType"`
+	Lata     string   `xml:"Lata"`
+	Quantity int      `xml:"Quantity"`
+}
+
+// CombinedSearchAndOrderType is an order type defining an order based on a combination of search parameters.
+type CombinedSearchAndOrderType struct {
+	XMLName    xml.Name `xml:"CombinedSearchAndOrderType"`
+	Quantity   int      `xml:"Quantity"`
+	AreaCode   int      `xml:"AreaCode,omitempty"`
+	RateCenter string   `xml:"RateCenter,omitempty"`
+	State      string   `xml:"State,omitempty"`
+	Lata       string   `xml:"Lata,omitempty"`
+	City       string   `xml:"City,omitempty"`
+	Zip        string   `xml:"Zip,omitempty"`
+}
+
+// Order is an order for a telephone number.
+type Order struct {
+	XMLName            xml.Name   `xml:"Order"`
+	ID                 string     `xml:"id,omitempty"`
+	CustomerOrderID    string     `xml:"CustomerOrderId"`
+	Name               string     `xml:"Name"`
+	OrderCreatedDate   *time.Time `xml:"OrderCreateDate,omitempty"`
+	PeerID             string     `xml:"PeerId,omitempty"`
+	BackOrderRequested bool       `xml:"BackOrderRequested"`
+	TnAttributes       []string   `xml:"TnAttributes,omitempty>TnAttribute,omitempty"`
+	PartialAllowed     bool       `xml:"PartialAllowed"`
+	SiteID             string     `xml:"SiteId"`
+
+	// Different order types for the order, only one of the following should be
+	// and will be defined for an Order.
+	ExistingTelephoneNumberOrder   *ExistingTelephoneNumberOrderType   `xml:"ExistingTelephoneNumberOrderType,omitempty"`
+	AreaCodeSearchAndOrder         *AreaCodeSearchAndOrderType         `xml:"AreaCodeSearchAndOrderType,omitempty"`
+	RateCenterSearchAndOrder       *RateCenterSearchAndOrderType       `xml:"RateCenterSearchAndOrderType,omitempty"`
+	TollFreeVanitySearchAndOrder   *TollFreeVanitySearchAndOrderType   `xml:"TollFreeVanitySearchAndOrderType,omitempty"`
+	TollFreeWildCharSearchAndOrder *TollFreeWildCharSearchAndOrderType `xml:"TollFreeWildCharSearchAndOrderType,omitempty"`
+	StateSearchAndOrder            *StateSearchAndOrderType            `xml:"StateSearchAndOrderType,omitempty"`
+	CitySearchAndOrder             *CitySearchAndOrderType             `xml:"CitySearchAndOrderType,omitempty"`
+	ZIPSearchAndOrder              *ZIPSearchAndOrderType              `xml:"ZIPSearchAndOrderType,omitempty"`
+	LATASearchAndOrder             *LATASearchAndOrderType             `xml:"LATASearchAndOrderType,omitempty"`
+	CombinedSearchAndOrder         *CombinedSearchAndOrderType         `xml:"CombinedSearchAndOrderType,omitempty"`
+}
+
+// GetOrderResponse is the response for GetOrder.
+type GetOrderResponse struct {
+	XMLName           xml.Name   `xml:"OrderResponse"`
+	CompletedQuantity int        `xml:"CompletedQuantity"`
+	CreatedByUser     string     `xml:"CreatedByUser"`
+	LastModifiedDate  *time.Time `xml:"LastModifiedDate"`
+	OrderCompleteDate *time.Time `xml:"OrderCompleteDate"`
+	Order             Order      `xml:"Order"`
+	OrderStatus       string     `xml:"OrderStatus"`
+	CompletedNumbers  []string   `xml:"CompletedNumbers>TelephoneNumber>FullNumber"`
+	FailedQuantity    int        `xml:"FailedQuantity"`
+}
+
+// GetOrder gets an order.
+func (c *Client) GetOrder(orderID string) (*GetOrderResponse, error) {
+	respBody := &GetOrderResponse{}
+	err := c.makeRequest(http.MethodGet, fmt.Sprintf("orders/%s", orderID), nil, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
+// CreateOrderResponse is the response for CreateOrder.
+type CreateOrderResponse struct {
+	XMLName xml.Name `xml:"OrderResponse"`
+	Order   Order    `xml:"Order"`
+}
+
+// CreateOrder creates a new order.
+func (c *Client) CreateOrder(data *Order) (*CreateOrderResponse, error) {
+	respBody := &CreateOrderResponse{}
+	err := c.makeRequest(http.MethodPost, "orders", data, respBody)
+	if err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}


### PR DESCRIPTION
Adds a new submodule of v2/numbers to highlight that its specific to v2 and only the numbers API. Being that the v2 API is broken down into different micro API's it seemed fitting that each be in its own submodule. v2/numbers is XML based being different from the v1 JSON based API.

The v2/numbers API is rather large this only adds the basics for my needs plus a little bit more (somethings I do not need at the moment, but went ahead and added it for more completeness).